### PR TITLE
fix compilation error when building with maven

### DIFF
--- a/src/test/java/testenv/CompilationException.java
+++ b/src/test/java/testenv/CompilationException.java
@@ -7,10 +7,6 @@ public class CompilationException extends Exception {
 		super();
 	}
 
-	public CompilationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
-	}
-
 	public CompilationException(String message, Throwable cause) {
 		super(message, cause);
 	}


### PR DESCRIPTION
An error in the test code prevents the project from being build with maven. I removed the seemingly unneccassary constructor from CompilationError to fix this.
