### PR TITLE
Fix for using withCopyMethod together with withGenerationGap

### DIFF
--- a/src/main/templates/Builder-template.stg
+++ b/src/main/templates/Builder-template.stg
@@ -73,7 +73,7 @@ public <if(model.abstractClass)>abstract <endif>class <model.type.genericTypeSim
 	public <model.selfType.genericTypeSimpleName> copy(<model.productType.genericTypeSimpleName> original) {
 		<model.propertiesForCopyByFieldAccess:copyPropertyByFieldAccess()>
 		<model.propertiesForCopyByGetter:copyPropertyByGetter()>
-		return this;
+		return self;
 	}
 	<endif>
 }


### PR DESCRIPTION
When using withCopyMethod together with withGenerationGap the generated builder does not compile, as it returns this in the copy method, which is of course an instance of the abstract builder and not an instance of the builder. Instead, we return now self, which fixes that problem.
