### PR TITLE
FIX do include fields in copy method which are not accessible

### DIFF
--- a/src/main/java/net/karneim/pojobuilder/model/BuilderM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/BuilderM.java
@@ -150,9 +150,8 @@ public class BuilderM extends BaseBuilderM {
 		Iterator<PropertyM> it = result.iterator();
 		while (it.hasNext()) {
 			PropertyM p = it.next();
-			if (!p.isAccessible()) {
-				it.remove();
-			} else if (!p.isReadable() && !p.isHasGetter()) {
+
+			if (!p.isReadable() && !p.isHasGetter()) {
 				it.remove();
 			}
 		}


### PR DESCRIPTION
Although a field is not accessible, it might still be set via a setter for example.

As long as there is a corresponding withXY method, we should include that field in the copy method.
