### PR TITLE
Issue 44 - Simple implementation of varargs for lists

### DIFF
--- a/src/main/java/net/karneim/pojobuilder/model/TypeM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/TypeM.java
@@ -1,6 +1,7 @@
 package net.karneim.pojobuilder.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -102,6 +103,10 @@ public class TypeM {
         return this.equals(OBJECT);
     }
 
+    public boolean isList() {
+    	return List.class.getName().equals(getQualifiedName());
+    }
+
     public void addToImportTypes(Set<String> result) {
         String importName = getImportName();
         if (importName != null) {
@@ -111,6 +116,11 @@ public class TypeM {
             for (TypeParameterM typeParam : getTypeParameters()) {
                 typeParam.addToImportTypes(result);
             }
+        }
+        if (isList()) {
+        	result.add(List.class.getName());
+        	result.add(ArrayList.class.getName());
+        	result.add(Arrays.class.getName());
         }
     }
 

--- a/src/main/templates/Builder-template.stg
+++ b/src/main/templates/Builder-template.stg
@@ -111,6 +111,19 @@ public <model.selfType.genericTypeSimpleName> with<property.nameUC>( <property.t
     return self;
 }
 
+<if(property.type.list)>
+/**
+ * Sets the content of the default value for the {@link List} {@link <model.productType.simpleName>#<property.name>} property.
+ * The values are added to an {@link ArrayList}.
+ * @param values the default values
+ * @return this builder
+ */
+public <model.selfType.genericTypeSimpleName> with<property.nameUC>( <first(property.type.typeParameters).name>... values) {
+    return with<property.nameUC>(new ArrayList\<<first(property.type.typeParameters).name>\>(Arrays.asList(values)));
+}
+
+<endif>
+
 >>
 
 propertySetterCall(property) ::= <<

--- a/src/test/java/net/karneim/pojobuilder/ListTest.java
+++ b/src/test/java/net/karneim/pojobuilder/ListTest.java
@@ -1,0 +1,68 @@
+package net.karneim.pojobuilder;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.TreeSet;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+
+import net.karneim.pojobuilder.model.BuilderM;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import testdata.generics.NumberGrid;
+import testenv.AddToSourceTree;
+import testenv.ProcessingEnvironmentRunner;
+
+@RunWith(ProcessingEnvironmentRunner.class)
+@AddToSourceTree({ TestBase.SRC_TESTDATA_DIR })
+public class ListTest extends TestBase {
+	
+	private ProcessingEnvironment env;
+
+    private BuilderModelProducer underTest;
+
+    @Before
+    public void setup() {
+        env = ProcessingEnvironmentRunner.getProcessingEnvironment();
+        TypeMUtils typeMUtils = new TypeMUtils();
+        underTest = new BuilderModelProducer(env, typeMUtils);
+    }
+
+	@Test
+    public void testProduceModelReturnsModelThatDetectsLists() {
+        // Given:
+        String pojoClassname = NumberGrid.class.getCanonicalName();
+        TypeElement pojoTypeElement = env.getElementUtils().getTypeElement(pojoClassname);
+
+        // When:
+        Output output = underTest.produce(new Input(pojoTypeElement));
+        BuilderM builder = output.getBuilder();
+
+        // Then:
+        assertTrue("isList", builder.getProperties().iterator().next().getType().isList());
+    }
+	
+	@Test
+    public void testProduceModelReturnsModelThatAddListSpecificImports() {
+        // Given:
+        String pojoClassname = NumberGrid.class.getCanonicalName();
+        TypeElement pojoTypeElement = env.getElementUtils().getTypeElement(pojoClassname);
+        TreeSet<String> additionalImports = new TreeSet<String>();
+
+        // When:
+        Output output = underTest.produce(new Input(pojoTypeElement));
+        BuilderM builder = output.getBuilder();
+        builder.getProperties().iterator().next().getType().addToImportTypes(additionalImports);
+
+        // Then:
+		assertArrayEquals(
+			new String[]{"java.util.ArrayList", "java.util.Arrays", "java.util.Collection", "java.util.List"},
+			additionalImports.toArray(new String[0]));
+    }
+
+}


### PR DESCRIPTION
I developed this little feature for version 2.4.2 because it'd make my team's (and hopefully many others) work a little bit easier every day.
It overloads a `withSomeList(List<Foo> value)` method by a varargs variant (`withSomeList(Foo... values)`) using the generic type of that List (maybe there is need for a fallback when no generics are used). An (modifiable) ArrayList is used as implementation.
See also: [Issue 44](https://github.com/mkarneim/pojobuilder/issues/44)
