### PR TITLE
Stop catching Error in build method

### DIFF
--- a/src/main/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator.java
+++ b/src/main/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator.java
@@ -291,8 +291,8 @@ public class BuilderSourceGenerator {
           .emitStatement("return result")
         .nextControlFlow("catch (RuntimeException ex)")
           .emitStatement("throw ex")
-        .nextControlFlow("catch (Throwable t)")
-          .emitStatement("throw new java.lang.reflect.UndeclaredThrowableException(t)")
+        .nextControlFlow("catch (Exception ex)")
+          .emitStatement("throw new java.lang.reflect.UndeclaredThrowableException(ex)")
         .endControlFlow()
       .endMethod();
     // @formatter:on

--- a/src/test/resources/net/karneim/pojobuilder/processor/with/baseclass/andgenerationgap/AbstractPojo1Builder.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/processor/with/baseclass/andgenerationgap/AbstractPojo1Builder.expected.txt
@@ -67,8 +67,8 @@ public abstract class AbstractPojo1Builder extends SimpleBaseBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/processor/with/baseclass/andgenerationgap/AbstractPojo2Builder.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/processor/with/baseclass/andgenerationgap/AbstractPojo2Builder.expected.txt
@@ -68,8 +68,8 @@ public abstract class AbstractPojo2Builder extends BaseBuilderWithGenericBuildMe
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/processor/with/baseclass/andgenerationgap/AbstractPojo3Builder.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/processor/with/baseclass/andgenerationgap/AbstractPojo3Builder.expected.txt
@@ -68,8 +68,8 @@ public abstract class AbstractPojo3Builder extends BaseBuilderWithRawBuildMethod
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/processor/with/builderdependencies/PojoFBuilder.java.txt
+++ b/src/test/resources/net/karneim/pojobuilder/processor/with/builderdependencies/PojoFBuilder.java.txt
@@ -84,8 +84,8 @@ public class PojoFBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/processor/with/generationgap/AbstractOrderBuilder.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/processor/with/generationgap/AbstractOrderBuilder.expected.txt
@@ -102,8 +102,8 @@ public abstract class AbstractOrderBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateCopyMethod.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateCopyMethod.expected.txt
@@ -114,8 +114,8 @@ public class SampleBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateMinimalBuilder.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateMinimalBuilder.expected.txt
@@ -50,8 +50,8 @@ public class SampleBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateWithBaseclass.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateWithBaseclass.expected.txt
@@ -51,8 +51,8 @@ public class SampleBuilder extends BaseBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/GenericProperties.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/GenericProperties.expected.txt
@@ -86,8 +86,8 @@ public class SampleBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/ObjectProperties.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/ObjectProperties.expected.txt
@@ -120,8 +120,8 @@ public class SampleBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/ParameterizedGenericProperties.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/ParameterizedGenericProperties.expected.txt
@@ -70,8 +70,8 @@ public class SampleBuilder<K, V extends Number>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/PrimitiveProperties.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/PrimitiveProperties.expected.txt
@@ -186,8 +186,8 @@ public class SampleBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/array/GenericPojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/array/GenericPojoBuilder.java
@@ -103,8 +103,8 @@ public class GenericPojoBuilder<T extends Object>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/array/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/array/PojoBuilder.java
@@ -102,8 +102,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/baseclass/Pojo1Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/baseclass/Pojo1Builder.java
@@ -67,8 +67,8 @@ public class Pojo1Builder extends SimpleBaseBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/baseclass/Pojo2Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/baseclass/Pojo2Builder.java
@@ -68,8 +68,8 @@ public class Pojo2Builder extends BaseBuilderWithGenericBuildMethod<Pojo2>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/baseclass/Pojo3Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/baseclass/Pojo3Builder.java
@@ -68,8 +68,8 @@ public class Pojo3Builder extends BaseBuilderWithRawBuildMethod
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinterface/AnotherPojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinterface/AnotherPojoBuilder.java
@@ -140,8 +140,8 @@ public class AnotherPojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinterface/GenericPojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinterface/GenericPojoBuilder.java
@@ -113,8 +113,8 @@ public class GenericPojoBuilder<P extends Number>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinterface/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinterface/PojoBuilder.java
@@ -144,8 +144,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/classannotation/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/classannotation/PojoBuilder.java
@@ -67,8 +67,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/constructorannotation/Pojo1Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/constructorannotation/Pojo1Builder.java
@@ -64,8 +64,8 @@ public class Pojo1Builder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/constructorannotation/Pojo2Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/constructorannotation/Pojo2Builder.java
@@ -78,8 +78,8 @@ public class Pojo2Builder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/copymethod/AddressBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/copymethod/AddressBuilder.java
@@ -114,8 +114,8 @@ public class AddressBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/copymethod/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/copymethod/PojoBuilder.java
@@ -108,8 +108,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/customannotation/builder/FluentPojoABBuilderB.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/customannotation/builder/FluentPojoABBuilderB.java
@@ -79,8 +79,8 @@ public class FluentPojoABBuilderB
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/customannotation/builder/FluentPojoABuilderA.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/customannotation/builder/FluentPojoABuilderA.java
@@ -68,8 +68,8 @@ public class FluentPojoABuilderA
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/customannotation/builder/FluentPojoCBuilderB.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/customannotation/builder/FluentPojoCBuilderB.java
@@ -79,8 +79,8 @@ public class FluentPojoCBuilderB
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/enums/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/enums/PojoBuilder.java
@@ -67,8 +67,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/ContainerBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/ContainerBuilder.java
@@ -66,8 +66,8 @@ public class ContainerBuilder<X extends Number>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/FileContainerBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/FileContainerBuilder.java
@@ -65,8 +65,8 @@ public class FileContainerBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/GenericListContainerBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/GenericListContainerBuilder.java
@@ -67,8 +67,8 @@ public class GenericListContainerBuilder<T extends Object>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/PairBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/PairBuilder.java
@@ -80,8 +80,8 @@ public class PairBuilder<L extends Object, R extends Object>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/ProductBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/ProductBuilder.java
@@ -79,8 +79,8 @@ public class ProductBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/ResourceBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/ResourceBuilder.java
@@ -78,8 +78,8 @@ public class ResourceBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/StringPairBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/StringPairBuilder.java
@@ -78,8 +78,8 @@ public class StringPairBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/TPairBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/factorymethodannotation/TPairBuilder.java
@@ -80,8 +80,8 @@ public class TPairBuilder<T extends Object>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/generationgap/AbstractPlayerBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/generationgap/AbstractPlayerBuilder.java
@@ -81,8 +81,8 @@ public abstract class AbstractPlayerBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/generics/PairBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/generics/PairBuilder.java
@@ -86,8 +86,8 @@ public class PairBuilder<A extends Comparable<A>, B extends Number>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/generics/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/generics/PojoBuilder.java
@@ -122,8 +122,8 @@ public class PojoBuilder<T extends Object>
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/innerclass/InnerPojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/innerclass/InnerPojoBuilder.java
@@ -102,8 +102,8 @@ public class InnerPojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/intopackage/builder/SampleBean3Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/intopackage/builder/SampleBean3Builder.java
@@ -65,8 +65,8 @@ public class SampleBean3Builder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/name/FluentSampleBean4Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/name/FluentSampleBean4Builder.java
@@ -64,8 +64,8 @@ public class FluentSampleBean4Builder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/optionals/PojoWithGuavaOptional2Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/optionals/PojoWithGuavaOptional2Builder.java
@@ -68,8 +68,8 @@ public class PojoWithGuavaOptional2Builder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/optionals/PojoWithGuavaOptionalBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/optionals/PojoWithGuavaOptionalBuilder.java
@@ -122,8 +122,8 @@ public class PojoWithGuavaOptionalBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/settername/Pojo2Builder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/settername/Pojo2Builder.java
@@ -84,8 +84,8 @@ public class Pojo2Builder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/settername/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/settername/PojoBuilder.java
@@ -84,8 +84,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/validator/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/validator/PojoBuilder.java
@@ -69,8 +69,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/varargs/OtherPojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/varargs/OtherPojoBuilder.java
@@ -100,8 +100,8 @@ public class OtherPojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/varargs/PojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/varargs/PojoBuilder.java
@@ -111,8 +111,8 @@ public class PojoBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/AbstractPlayerBuilder.java
+++ b/src/testdata/java/samples/AbstractPlayerBuilder.java
@@ -81,8 +81,8 @@ public abstract class AbstractPlayerBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/AddressBuilder.java
+++ b/src/testdata/java/samples/AddressBuilder.java
@@ -147,8 +147,8 @@ public class AddressBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/ContactBuilder.java
+++ b/src/testdata/java/samples/ContactBuilder.java
@@ -95,8 +95,8 @@ public class ContactBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/CredentialsBuilder.java
+++ b/src/testdata/java/samples/CredentialsBuilder.java
@@ -86,8 +86,8 @@ public class CredentialsBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/FileBuilder.java
+++ b/src/testdata/java/samples/FileBuilder.java
@@ -65,8 +65,8 @@ public class FileBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/ItemBuilder.java
+++ b/src/testdata/java/samples/ItemBuilder.java
@@ -107,8 +107,8 @@ public class ItemBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/OrderBuilder.java
+++ b/src/testdata/java/samples/OrderBuilder.java
@@ -116,8 +116,8 @@ public class OrderBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/RecipientBuilder.java
+++ b/src/testdata/java/samples/RecipientBuilder.java
@@ -115,8 +115,8 @@ public class RecipientBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/TextEmailBuilder.java
+++ b/src/testdata/java/samples/TextEmailBuilder.java
@@ -132,8 +132,8 @@ public class TextEmailBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/UrlBuilder.java
+++ b/src/testdata/java/samples/UrlBuilder.java
@@ -122,8 +122,8 @@ public class UrlBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/UserBuilder.java
+++ b/src/testdata/java/samples/UserBuilder.java
@@ -84,8 +84,8 @@ public class UserBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }

--- a/src/testdata/java/samples/dsl/StringBuilder.java
+++ b/src/testdata/java/samples/dsl/StringBuilder.java
@@ -108,8 +108,8 @@ public class StringBuilder
       return result;
     } catch (RuntimeException ex) {
       throw ex;
-    } catch (Throwable t) {
-      throw new java.lang.reflect.UndeclaredThrowableException(t);
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
     }
   }
 }


### PR DESCRIPTION
`catch (Throwable t)` gets picked up by every code analysis tool as a "bad thing"
(VM level) Errors should not be caught except by code designed specifically to handle them.

Supplied code is more idiomatic Java for doing this (without Guava's Throwables class!)
