### PR TITLE
Making PojoBuilder compile with Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+sudo: false
 language: java
-
+jdk:
+  - oraclejdk8
+  - oraclejdk7
 after_success:
 - ./gradlew jacocoTestReport coveralls

--- a/src/main/java/net/karneim/pojobuilder/GeneratePojoBuilder.java
+++ b/src/main/java/net/karneim/pojobuilder/GeneratePojoBuilder.java
@@ -166,7 +166,7 @@ public @interface GeneratePojoBuilder {
    * <p>
    * The property pattern consists of a name pattern followed by an optional type pattern.
    * <p>
-   * The syntax is <code>&lt;name pattern&gt;[:&lt;type pattern&gt].</code> The pattern supports the asterisk '*'
+   * The syntax is <code>&lt;name pattern&gt;[:&lt;type pattern&gt;].</code> The pattern supports the asterisk '*'
    * wildcard character that matches any character.
    * <p>
    * Default is '*'.
@@ -183,7 +183,7 @@ public @interface GeneratePojoBuilder {
    * <p>
    * The property pattern consists of a name pattern followed by an optional type pattern.
    * <p>
-   * The syntax is <code>&lt;name pattern&gt;[:&lt;type pattern&gt].</code> The pattern supports the asterisk '*'
+   * The syntax is <code>&lt;name pattern&gt;[:&lt;type pattern&gt;].</code> The pattern supports the asterisk '*'
    * wildcard character that matches any character.
    * <p>
    * Default is the empty array.

--- a/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzerUtil.java
+++ b/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzerUtil.java
@@ -307,7 +307,7 @@ public class JavaModelAnalyzerUtil {
   /**
    * Returns true if the given type element defines a public no-args constructor.
    * 
-   * @param typeEl
+   * @param typeEl Type element.
    * @return true if the given type element defines a public no-args constructor
    */
   public boolean hasPublicNoArgsConstructor(TypeElement typeEl) {

--- a/src/main/java/net/karneim/pojobuilder/model/PropertyM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/PropertyM.java
@@ -65,6 +65,8 @@ public class PropertyM {
   /**
    * The {@link TypeM} for an optional property supplied by the given optional type.
    *
+   * @param optionalType The optional property to get
+   *
    * @return null if there is no optional type available for this property
    */
   public TypeM getOptionalPropertyType(TypeM optionalType) {


### PR DESCRIPTION
 * Failed because Java 8 by default does lint check on Javadoc.
 * Also adding Java 7 and 8 to Travis.