### PR TITLE
Basic support for builder inheritance

### DIFF
--- a/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzer.java
+++ b/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzer.java
@@ -42,7 +42,7 @@ public class JavaModelAnalyzer {
 
     TypeM pojoType = typeMFactory.getTypeM(input.getPojoType());
     result.getBuilderModel().setPojoType(pojoType);
-    result.getBuilderModel().setBuildMethod(new BuildMethodM());
+    processBuildMethod(result);
     processCloneMethod(result);
 
     if (input.getDirectives().isGenerationGap()) {
@@ -88,6 +88,15 @@ public class JavaModelAnalyzer {
     result.getBuilderModel().getProperties()
         .removePropertiesMatchingAnyOf(input.getDirectives().getExcludeProperties());
     return result;
+  }
+
+  private void processBuildMethod(Output output) {
+    if (javaModelAnalyzerUtil.isAbstract(output.getInput().getPojoElement())) {
+      output.getBuilderModel().setAbstract(true);
+      output.getBuilderModel().setBuildMethod(new BuildMethodM(Modifier.ABSTRACT));
+    } else {
+      output.getBuilderModel().setBuildMethod(new BuildMethodM());
+    }
   }
 
   private void setPropertiesMethodNames(Output output) {

--- a/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzerUtil.java
+++ b/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzerUtil.java
@@ -253,7 +253,7 @@ public class JavaModelAnalyzerUtil {
   }
 
   /**
-   * Returns true, if the given type element has a method with the given name and has an actual
+   * Finds a method, if the given type element has a method with the given name and has an actual
    * return type that is compatible with the given return type, and has an actual parameter that is
    * compatible with the given parameter type.
    *
@@ -262,9 +262,9 @@ public class JavaModelAnalyzerUtil {
    * @param requiredReturnType the required return type (maybe {@link NoType}).
    * @param requiredParamType the type of the required (first) parameter, or <code>null</code> if no
    *        parameter is required
-   * @return true, if the type element has the required method
+   * @return method if one matches or null
    */
-  public boolean hasMethod(TypeElement typeElement, String name, TypeMirror requiredReturnType,
+  public ExecutableElement getMethod(TypeElement typeElement, String name, TypeMirror requiredReturnType,
       TypeMirror requiredParamType) {
     List<? extends Element> memberEls = elements.getAllMembers(typeElement);
     List<ExecutableElement> methodEls = ElementFilter.methodsIn(memberEls);
@@ -297,7 +297,40 @@ public class JavaModelAnalyzerUtil {
           continue;
         }
       }
-      return true;
+      return methodEl;
+    }
+    return null;
+  }
+
+  /**
+   * Returns true, if the given type element has a method with the given name and has an actual
+   * return type that is compatible with the given return type, and has an actual parameter that is
+   * compatible with the given parameter type.
+   *
+   * @param typeElement the type element
+   * @param name the required name of the method
+   * @param requiredReturnType the required return type (maybe {@link NoType}).
+   * @param requiredParamType the type of the required (first) parameter, or <code>null</code> if no
+   *        parameter is required
+   * @return true, if the type element has the required method
+   */
+  public boolean hasMethod(TypeElement typeElement, String name, TypeMirror requiredReturnType,
+                           TypeMirror requiredParamType) {
+    return getMethod(typeElement, name, requiredReturnType, requiredParamType) != null;
+  }
+
+  /**
+   * Determines if a given method throws a given exception.
+   * @param method the method to analyse
+   * @param throwable throwable type to test for
+   * @return true if the method throws this exception or anything assignable to it
+   */
+  public boolean hasThrows(ExecutableElement method, TypeElement throwable) {
+    TypeMirror throwableType = throwable.asType();
+    for (TypeMirror candidate : method.getThrownTypes()) {
+      if (types.isAssignable(candidate, throwableType)) {
+        return true;
+      }
     }
     return false;
   }

--- a/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzerUtil.java
+++ b/src/main/java/net/karneim/pojobuilder/analysis/JavaModelAnalyzerUtil.java
@@ -1,9 +1,7 @@
 package net.karneim.pojobuilder.analysis;
 
 import static javax.lang.model.element.ElementKind.CLASS;
-import static javax.lang.model.element.Modifier.PRIVATE;
-import static javax.lang.model.element.Modifier.PUBLIC;
-import static javax.lang.model.element.Modifier.STATIC;
+import static javax.lang.model.element.Modifier.*;
 import static javax.lang.model.type.TypeKind.VOID;
 
 import java.util.ArrayList;
@@ -434,6 +432,10 @@ public class JavaModelAnalyzerUtil {
       findAnnotatedElements(result, unit, annotationType);
     }
     return result;
+  }
+
+  public boolean isAbstract(TypeElement element) {
+    return element.getModifiers().contains(ABSTRACT);
   }
 
   private void findAnnotatedElements(List<Element> result, Element element,

--- a/src/main/java/net/karneim/pojobuilder/model/BuildMethodM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/BuildMethodM.java
@@ -2,6 +2,8 @@ package net.karneim.pojobuilder.model;
 
 import javax.lang.model.element.Modifier;
 
+import java.util.EnumSet;
+
 import static java.util.Collections.singleton;
 
 public class BuildMethodM extends MethodM {
@@ -10,4 +12,7 @@ public class BuildMethodM extends MethodM {
     super("build", singleton(Modifier.PUBLIC));
   }
 
+  public BuildMethodM(Modifier modifier) {
+    super("build", EnumSet.of(Modifier.PUBLIC, modifier));
+  }
 }

--- a/src/main/java/net/karneim/pojobuilder/model/BuildMethodM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/BuildMethodM.java
@@ -1,22 +1,13 @@
 package net.karneim.pojobuilder.model;
 
-public class BuildMethodM {
-  private boolean overrides;
+import javax.lang.model.element.Modifier;
 
-  public BuildMethodM() {}
+import static java.util.Collections.singleton;
 
-  public boolean isOverrides() {
-    return overrides;
-  }
+public class BuildMethodM extends MethodM {
 
-  public BuildMethodM setOverrides(boolean value) {
-    this.overrides = value;
-    return this;
-  }
-
-  @Override
-  public String toString() {
-    return "BuildMethodM [overrides=" + overrides + "]";
+  public BuildMethodM() {
+    super("build", singleton(Modifier.PUBLIC));
   }
 
 }

--- a/src/main/java/net/karneim/pojobuilder/model/BuilderM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/BuilderM.java
@@ -10,6 +10,7 @@ public class BuilderM {
   private PropertyListM properties = new PropertyListM();
   private FactoryMethodM factoryMethod;
   private CopyMethodM copyMethod;
+  private CloneMethodM cloneMethod;
   private BuildMethodM buildMethod;
   private ValidatorM validator;
   private TypeM interfaceType;
@@ -79,6 +80,14 @@ public class BuilderM {
 
   public void setCopyMethod(CopyMethodM copyMethod) {
     this.copyMethod = copyMethod;
+  }
+
+  public CloneMethodM getCloneMethod() {
+    return cloneMethod;
+  }
+
+  public void setCloneMethod(CloneMethodM cloneMethod) {
+    this.cloneMethod = cloneMethod;
   }
 
   public BuildMethodM getBuildMethod() {

--- a/src/main/java/net/karneim/pojobuilder/model/CloneMethodM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/CloneMethodM.java
@@ -1,0 +1,22 @@
+package net.karneim.pojobuilder.model;
+
+import javax.lang.model.element.Modifier;
+
+import static java.util.Collections.singleton;
+
+public class CloneMethodM extends MethodM {
+
+  private boolean catchesCloneException = true;
+
+  public CloneMethodM() {
+    super("clone", singleton(Modifier.PUBLIC));
+  }
+
+  public boolean isCatchesCloneException() {
+    return catchesCloneException;
+  }
+
+  public void setCatchesCloneException(boolean catchesCloneException) {
+    this.catchesCloneException = catchesCloneException;
+  }
+}

--- a/src/main/java/net/karneim/pojobuilder/model/CopyMethodM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/CopyMethodM.java
@@ -1,20 +1,13 @@
 package net.karneim.pojobuilder.model;
 
-public class CopyMethodM {
-  private final String name;
+import javax.lang.model.element.Modifier;
+
+import static java.util.Collections.singleton;
+
+public class CopyMethodM extends MethodM {
 
   public CopyMethodM(String name) {
-    super();
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public String toString() {
-    return "CopyMethodM [name=" + name + "]";
+    super(name, singleton(Modifier.PUBLIC));
   }
 
 }

--- a/src/main/java/net/karneim/pojobuilder/model/MethodM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/MethodM.java
@@ -12,6 +12,7 @@ public class MethodM {
   private String name;
   private Set<Modifier> modifiers;
   private TypeM declaringClass;
+  private boolean overrides;
 
   public MethodM(String name, Set<Modifier> modifiers) {
     super();
@@ -56,10 +57,18 @@ public class MethodM {
     return accessingClass.isInPackage(declaringClass.getPackageName());
   }
 
+  public boolean isOverrides() {
+    return overrides;
+  }
+
+  public void setOverrides(boolean value) {
+    this.overrides = value;
+  }
+
   @Override
   public String toString() {
     return "MethodM [name=" + name + ", modifiers=" + modifiers + ", declaringClass="
-        + declaringClass + "]";
+        + declaringClass + ", overrides="+overrides+"]";
   }
 
 

--- a/src/main/java/net/karneim/pojobuilder/model/TypeListM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/TypeListM.java
@@ -65,16 +65,21 @@ public class TypeListM extends ArrayList<TypeM> {
     return this.toArray(new TypeM[size()]);
   }
 
-  public TypeListM collectDistinctTypeVariablesRecursevly(TypeListM result) {
+  public TypeListM distinctTypeVariables() {
+    TypeListM distinct = new TypeListM();
+    collectDistinctTypeVariablesRecursively(distinct);
+    return distinct;
+  }
+
+  private void collectDistinctTypeVariablesRecursively(TypeListM result) {
     for (TypeM type : this) {
       if (type.isTypeVariable()) {
         if (!result.contains(type)) {
           result.add(type);
         }
       } else {
-        type.getTypeParameters().collectDistinctTypeVariablesRecursevly(result);
+        type.getTypeParameters().collectDistinctTypeVariablesRecursively(result);
       }
     }
-    return result;
   }
 }

--- a/src/main/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator.java
+++ b/src/main/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator.java
@@ -195,7 +195,7 @@ public class BuilderSourceGenerator {
          "Copies the values from the given pojo into this builder.\n\n"
         +"@param pojo\n"
         +"@return this builder")
-      .beginMethod(selfTypeDeclaration, copyMethodM.getName(), EnumSet.of(PUBLIC), pojoTypeDeclaration, "pojo");
+      .beginMethod(selfTypeDeclaration, copyMethodM.getName(), copyMethodM.getModifiers(), pojoTypeDeclaration, "pojo");
 
     PropertyListM getterProperties = properties.filterOutPropertiesReadableViaGetterCall(builderType);
     for( PropertyM prop : getterProperties) {
@@ -231,7 +231,7 @@ public class BuilderSourceGenerator {
     if (buildMethod.isOverrides()) {
       writer.emitAnnotation(Override.class);
     }
-    writer.beginMethod(pojoTypeDeclaration, "build", EnumSet.of(PUBLIC)).beginControlFlow("try");
+    writer.beginMethod(pojoTypeDeclaration, buildMethod.getName(), buildMethod.getModifiers()).beginControlFlow("try");
 
     if (!hasBuilderProperties) {
       if (factoryMethod == null) {

--- a/src/main/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator.java
+++ b/src/main/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator.java
@@ -220,8 +220,13 @@ public class BuilderSourceGenerator {
     if (buildMethod.isOverrides()) {
       writer.emitAnnotation(Override.class);
     }
-    writer.beginMethod(pojoTypeDeclaration, buildMethod.getName(), buildMethod.getModifiers()).beginControlFlow("try");
+    writer.beginMethod(pojoTypeDeclaration, buildMethod.getName(), buildMethod.getModifiers());
+    if ( buildMethod.getModifiers().contains(ABSTRACT)) {
+      writer.endMethod();
+      return;
+    }
 
+    writer.beginControlFlow("try");
     if (!hasBuilderProperties) {
       if (factoryMethod == null) {
         String arguments =

--- a/src/test/java/net/karneim/pojobuilder/analysis/with/baseclass/JavaModelAnalyzer_WithBaseclass_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/analysis/with/baseclass/JavaModelAnalyzer_WithBaseclass_Test.java
@@ -6,6 +6,7 @@ import net.karneim.pojobuilder.analysis.with.AnalysisTestSupport;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 public class JavaModelAnalyzer_WithBaseclass_Test extends AnalysisTestSupport {
 
@@ -22,6 +23,7 @@ public class JavaModelAnalyzer_WithBaseclass_Test extends AnalysisTestSupport {
         "net.karneim.pojobuilder.analysis.with.baseclass.PojoBuilder");
     assertThat(output.getBuilderModel().getBaseType().getName()).isEqualTo(
         "net.karneim.pojobuilder.analysis.with.baseclass.BuilderBaseclass");
+    assertThat(output.getBuilderModel().getCloneMethod().isCatchesCloneException()).isFalse();
   }
 
 }

--- a/src/test/java/net/karneim/pojobuilder/analysis/with/builderinheritance/JavaModelAnalyzer_WithAbstractPojo_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/analysis/with/builderinheritance/JavaModelAnalyzer_WithAbstractPojo_Test.java
@@ -1,0 +1,27 @@
+package net.karneim.pojobuilder.analysis.with.builderinheritance;
+
+import net.karneim.pojobuilder.analysis.Input;
+import net.karneim.pojobuilder.analysis.Output;
+import net.karneim.pojobuilder.analysis.with.AnalysisTestSupport;
+import net.karneim.pojobuilder.analysis.with.baseclass.Pojo;
+import net.karneim.pojobuilder.processor.with.builderinheritance.AbstractPojo;
+import org.junit.Test;
+
+import javax.lang.model.element.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaModelAnalyzer_WithAbstractPojo_Test extends AnalysisTestSupport {
+
+  @Test
+  public void testAnalyze() {
+    // Given:
+    Input input = inputFor(AbstractPojo.class);
+    // When:
+    Output output = underTest.analyze(input);
+    // Then:
+    assertThat(output.getBuilderModel().isAbstract()).isTrue();
+    assertThat(output.getBuilderModel().getBuildMethod().getModifiers()).contains(Modifier.ABSTRACT);
+  }
+
+}

--- a/src/test/java/net/karneim/pojobuilder/processor/with/builderinheritance/AnnotationProcessor_BuilderInheritance_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/processor/with/builderinheritance/AnnotationProcessor_BuilderInheritance_Test.java
@@ -1,0 +1,50 @@
+package net.karneim.pojobuilder.processor.with.builderinheritance;
+
+import net.karneim.pojobuilder.processor.AnnotationProcessor;
+import net.karneim.pojobuilder.processor.with.ProcessorTestSupport;
+import net.karneim.pojobuilder.testenv.JavaProject.Compilation;
+import org.junit.Test;
+
+import static net.karneim.pojobuilder.PbAssertions.assertThat;
+
+/**
+ * @feature The {@link AnnotationProcessor} generates builder classes.
+ */
+public class AnnotationProcessor_BuilderInheritance_Test extends ProcessorTestSupport {
+
+
+  /**
+   * @scenario builder for an abstract pojo is itself abstract
+   */
+  @Test
+  public void testAbstractPojoGeneratesAbstractBuilder() {
+    // Given:
+    sourceFor(AbstractPojo.class);
+    // When:
+    prj.compile();
+    // Then:
+    assertThat(prj)
+        .generatedSameSourceAs(AbstractPojoBuilder.class)
+        .compiled(AbstractPojoBuilder.class)
+        .reported(Compilation.Success);
+  }
+
+  /**
+   * @scenario inheriting builders are created for a pojo annotated with @GeneratePojoBuilder baseclass of another builder
+   */
+  @Test
+  public void testShouldGenerateAppleBuilderInheritingFruitBuilder() {
+    // Given:
+    sourceFor(Fruit.class, Apple.class);
+    // When:
+    prj.compile();
+    // Then:
+    assertThat(prj)
+        .generatedSameSourceAs(FruitBuilder.class)
+        .generatedSameSourceAs(AppleBuilder.class)
+        .compiled(FruitBuilder.class)
+        .compiled(AppleBuilder.class)
+        .reported(Compilation.Success);
+  }
+
+}

--- a/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateCloneMethod_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateCloneMethod_Test.java
@@ -1,0 +1,86 @@
+package net.karneim.pojobuilder.sourcegen;
+
+import com.squareup.javawriter.JavaWriter;
+import net.karneim.pojobuilder.model.*;
+import net.karneim.pojobuilder.testenv.TestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.EnumSet;
+
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BuilderSourceGenerator_GenerateCloneMethod_Test extends TestBase {
+
+  private StringWriter out;
+  private JavaWriter writer;
+  private BuilderSourceGenerator underTest;
+  private BuilderM builder;
+
+  @Before
+  public void init() {
+    out = new StringWriter();
+    writer = new JavaWriter(out);
+    underTest = new BuilderSourceGenerator(writer);
+  }
+
+  @Before
+  public void given() {
+    TypeM pojoType = new TypeM("com.example.output", "Sample");
+
+    builder = new BuilderM();
+    builder.setPojoType(pojoType);
+    builder.setProperties( new PropertyListM(
+        new PropertyM("someBoolean", PrimitiveTypeM.BOOLEAN)
+            .accessibleVia(new FieldAccessM(EnumSet.of(PUBLIC)).declaredIn(pojoType))
+            .withMethodNamePattern("with*"),
+        new PropertyM("someChar", PrimitiveTypeM.CHAR)
+            .accessibleVia(new FieldAccessM(EnumSet.of(PRIVATE)).declaredIn(pojoType))
+            .writableVia(new SetterMethodM("setSomeChar", EnumSet.of(PUBLIC)).declaredIn(pojoType))
+            .readableVia(new MethodM("getSomeChar", EnumSet.of(PUBLIC)).declaredIn(pojoType))
+            .withMethodNamePattern("with*"),
+        new PropertyM("someString", new TypeM("java.lang","String"))
+            .accessibleVia(new FieldAccessM(EnumSet.of(PUBLIC)))
+            .writableVia(new SetterMethodM("setSomeString", EnumSet.of(PUBLIC)).declaredIn(pojoType))
+            .readableVia(new MethodM("getSomeString", EnumSet.of(PUBLIC)).declaredIn(pojoType))
+            .withMethodNamePattern("with*")
+    ));
+    builder.setType(new TypeM("com.example.output","SampleBuilder"));
+    builder.setSelfType(builder.getType());
+    builder.setCopyMethod(new CopyMethodM("copy"));
+    builder.setBuildMethod( new BuildMethodM());
+    builder.setCloneMethod(new CloneMethodM());
+  }
+
+  @Test
+  public void testShouldGenerateCloneMethod() throws Exception {
+    // Given:
+    // When:
+    underTest.generateSource(builder);
+    // Then:
+    String actual = out.toString().replace("\r", "");
+    logDebug(actual);
+    String expected = loadResourceFromClasspath("GenerateCopyMethod.expected.txt");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void testShouldGenerateCloneMethodWithoutCatch() throws Exception {
+    // Given:
+    builder.getCloneMethod().setCatchesCloneException(false);
+    // When:
+    underTest.generateSource(builder);
+    // Then:
+    String actual = out.toString().replace("\r", "");
+    logDebug(actual);
+    String expected = loadResourceFromClasspath("GenerateCloneMethod.withoutCatch.expected.txt");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+
+}

--- a/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateCopyMethod_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateCopyMethod_Test.java
@@ -7,17 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.StringWriter;
 import java.util.EnumSet;
 
-import net.karneim.pojobuilder.model.BuildMethodM;
-import net.karneim.pojobuilder.model.BuilderM;
-import net.karneim.pojobuilder.model.ConstructorParameterM;
-import net.karneim.pojobuilder.model.CopyMethodM;
-import net.karneim.pojobuilder.model.FieldAccessM;
-import net.karneim.pojobuilder.model.MethodM;
-import net.karneim.pojobuilder.model.PrimitiveTypeM;
-import net.karneim.pojobuilder.model.PropertyListM;
-import net.karneim.pojobuilder.model.PropertyM;
-import net.karneim.pojobuilder.model.SetterMethodM;
-import net.karneim.pojobuilder.model.TypeM;
+import net.karneim.pojobuilder.model.*;
 import net.karneim.pojobuilder.testenv.TestBase;
 
 import org.junit.Before;
@@ -62,6 +52,7 @@ public class BuilderSourceGenerator_GenerateCopyMethod_Test extends TestBase {
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
     builder.setCopyMethod(new CopyMethodM("copy"));
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
 
     // Assume: properties are returned in insertion order
@@ -102,6 +93,7 @@ public class BuilderSourceGenerator_GenerateCopyMethod_Test extends TestBase {
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
     builder.setCopyMethod(new CopyMethodM("copy"));
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
 
     // Assume: properties are returned in insertion order

--- a/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test.java
@@ -200,7 +200,6 @@ public class BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test exten
     logDebug(actual);
     String expected = loadResourceFromClasspath("ParameterizedGenericProperties.expected.txt");
 
-    System.out.println(actual);
     assertThat(actual).isEqualTo(expected);
   }
 

--- a/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test.java
@@ -6,14 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.StringWriter;
 import java.util.EnumSet;
 
-import net.karneim.pojobuilder.model.BuildMethodM;
-import net.karneim.pojobuilder.model.BuilderM;
-import net.karneim.pojobuilder.model.FieldAccessM;
-import net.karneim.pojobuilder.model.PrimitiveTypeM;
-import net.karneim.pojobuilder.model.PropertyListM;
-import net.karneim.pojobuilder.model.PropertyM;
-import net.karneim.pojobuilder.model.TypeM;
-import net.karneim.pojobuilder.model.TypeVariableM;
+import net.karneim.pojobuilder.model.*;
 import net.karneim.pojobuilder.testenv.TestBase;
 
 import org.junit.Before;
@@ -76,6 +69,7 @@ public class BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test exten
 
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
 
     // When:
@@ -117,6 +111,7 @@ public class BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test exten
 
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
 
     // When:
@@ -155,6 +150,7 @@ public class BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test exten
 
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
 
     // When:
@@ -190,6 +186,7 @@ public class BuilderSourceGenerator_GenerateFieldPairsForEachProperty_Test exten
 
     builder.setType(new TypeM("com.example.output","SampleBuilder").withTypeParameter(K, V));
     builder.setSelfType(builder.getType());
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
 
     // When:

--- a/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateMinimalBuilder_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateMinimalBuilder_Test.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 
 import net.karneim.pojobuilder.model.BuildMethodM;
 import net.karneim.pojobuilder.model.BuilderM;
+import net.karneim.pojobuilder.model.CloneMethodM;
 import net.karneim.pojobuilder.model.TypeM;
 import net.karneim.pojobuilder.testenv.TestBase;
 
@@ -36,6 +37,7 @@ public class BuilderSourceGenerator_GenerateMinimalBuilder_Test extends TestBase
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
     builder.setBuildMethod( new BuildMethodM());
+    builder.setCloneMethod(new CloneMethodM());
 
     // When:
     underTest.generateSource(builder);

--- a/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateWithBaseclass_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/sourcegen/BuilderSourceGenerator_GenerateWithBaseclass_Test.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 
 import net.karneim.pojobuilder.model.BuildMethodM;
 import net.karneim.pojobuilder.model.BuilderM;
+import net.karneim.pojobuilder.model.CloneMethodM;
 import net.karneim.pojobuilder.model.TypeM;
 import net.karneim.pojobuilder.testenv.TestBase;
 
@@ -37,6 +38,7 @@ public class BuilderSourceGenerator_GenerateWithBaseclass_Test extends TestBase 
     builder.setType(new TypeM("com.example.output","SampleBuilder"));
     builder.setSelfType(builder.getType());
     builder.setBaseType(new TypeM("com.example.base","BaseBuilder"));
+    builder.setCloneMethod(new CloneMethodM());
     builder.setBuildMethod( new BuildMethodM());
     
     // When:

--- a/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateCloneMethod.withoutCatch.expected.txt
+++ b/src/test/resources/net/karneim/pojobuilder/sourcegen/GenerateCloneMethod.withoutCatch.expected.txt
@@ -1,0 +1,117 @@
+﻿package com.example.output;
+
+import javax.annotation.Generated;
+
+@Generated("PojoBuilder")
+public class SampleBuilder
+    implements Cloneable {
+  protected SampleBuilder self;
+  protected boolean value$someBoolean$boolean;
+  protected boolean isSet$someBoolean$boolean;
+  protected char value$someChar$char;
+  protected boolean isSet$someChar$char;
+  protected String value$someString$java$lang$String;
+  protected boolean isSet$someString$java$lang$String;
+
+  /**
+   * Creates a new {@link SampleBuilder}.
+   */
+  public SampleBuilder() {
+    self = (SampleBuilder)this;
+  }
+
+  /**
+   * Sets the default value for the {@link Sample#someBoolean} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public SampleBuilder withSomeBoolean(boolean value) {
+    this.value$someBoolean$boolean = value;
+    this.isSet$someBoolean$boolean = true;
+    return self;
+  }
+
+  /**
+   * Sets the default value for the {@link Sample#someChar} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public SampleBuilder withSomeChar(char value) {
+    this.value$someChar$char = value;
+    this.isSet$someChar$char = true;
+    return self;
+  }
+
+  /**
+   * Sets the default value for the {@link Sample#someString} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public SampleBuilder withSomeString(String value) {
+    this.value$someString$java$lang$String = value;
+    this.isSet$someString$java$lang$String = true;
+    return self;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  @Override
+  public Object clone() {
+    SampleBuilder result = (SampleBuilder)super.clone();
+    result.self = result;
+    return result;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  public SampleBuilder but() {
+    return (SampleBuilder)clone();
+  }
+
+  /**
+   * Copies the values from the given pojo into this builder.
+   *
+   * @param pojo
+   * @return this builder
+   */
+  public SampleBuilder copy(Sample pojo) {
+    withSomeChar(pojo.getSomeChar());
+    withSomeString(pojo.getSomeString());
+    withSomeBoolean(pojo.someBoolean);
+    return self;
+  }
+
+  /**
+   * Creates a new {@link Sample} based on this builder's settings.
+   *
+   * @return the created Sample
+   */
+  public Sample build() {
+    try {
+      Sample result = new Sample();
+      if (isSet$someChar$char) {
+        result.setSomeChar(value$someChar$char);
+      }
+      if (isSet$someString$java$lang$String) {
+        result.setSomeString(value$someString$java$lang$String);
+      }
+      if (isSet$someBoolean$boolean) {
+        result.someBoolean = value$someBoolean$boolean;
+      }
+      return result;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
+    }
+  }
+}

--- a/src/testdata/java/net/karneim/pojobuilder/analysis/with/baseclass/BuilderBaseclass.java
+++ b/src/testdata/java/net/karneim/pojobuilder/analysis/with/baseclass/BuilderBaseclass.java
@@ -2,4 +2,9 @@ package net.karneim.pojobuilder.analysis.with.baseclass;
 
 public class BuilderBaseclass {
 
+  @Override
+  protected Object clone() {
+    return null;
+  }
+
 }

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/AbstractPojo.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/AbstractPojo.java
@@ -1,0 +1,8 @@
+package net.karneim.pojobuilder.processor.with.builderinheritance;
+
+import net.karneim.pojobuilder.GeneratePojoBuilder;
+
+@GeneratePojoBuilder
+public abstract class AbstractPojo {
+  public int field;
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/AbstractPojoBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/AbstractPojoBuilder.java
@@ -1,0 +1,62 @@
+package net.karneim.pojobuilder.processor.with.builderinheritance;
+
+import javax.annotation.Generated;
+
+@Generated("PojoBuilder")
+public abstract class AbstractPojoBuilder
+    implements Cloneable {
+  protected AbstractPojoBuilder self;
+  protected int value$field$int;
+  protected boolean isSet$field$int;
+
+  /**
+   * Creates a new {@link AbstractPojoBuilder}.
+   */
+  public AbstractPojoBuilder() {
+    self = (AbstractPojoBuilder)this;
+  }
+
+  /**
+   * Sets the default value for the {@link AbstractPojo#field} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public AbstractPojoBuilder withField(int value) {
+    this.value$field$int = value;
+    this.isSet$field$int = true;
+    return self;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  @Override
+  public Object clone() {
+    try {
+      AbstractPojoBuilder result = (AbstractPojoBuilder)super.clone();
+      result.self = result;
+      return result;
+    } catch (CloneNotSupportedException e) {
+      throw new InternalError(e.getMessage());
+    }
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  public AbstractPojoBuilder but() {
+    return (AbstractPojoBuilder)clone();
+  }
+
+  /**
+   * Creates a new {@link AbstractPojo} based on this builder's settings.
+   *
+   * @return the created AbstractPojo
+   */
+  public abstract AbstractPojo build();
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/AppleBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/AppleBuilder.java
@@ -1,0 +1,88 @@
+package net.karneim.pojobuilder.processor.with.builderinheritance;
+
+import javax.annotation.Generated;
+
+@Generated("PojoBuilder")
+public class AppleBuilder extends FruitBuilder
+    implements Cloneable {
+  protected AppleBuilder self;
+  protected String value$colour$java$lang$String;
+  protected boolean isSet$colour$java$lang$String;
+  protected String value$variety$java$lang$String;
+  protected boolean isSet$variety$java$lang$String;
+
+  /**
+   * Creates a new {@link AppleBuilder}.
+   */
+  public AppleBuilder() {
+    self = (AppleBuilder)this;
+  }
+
+  /**
+   * Sets the default value for the {@link Apple#colour} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public AppleBuilder withColour(String value) {
+    this.value$colour$java$lang$String = value;
+    this.isSet$colour$java$lang$String = true;
+    return self;
+  }
+
+  /**
+   * Sets the default value for the {@link Apple#variety} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public AppleBuilder withVariety(String value) {
+    this.value$variety$java$lang$String = value;
+    this.isSet$variety$java$lang$String = true;
+    return self;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  @Override
+  public Object clone() {
+    AppleBuilder result = (AppleBuilder)super.clone();
+    result.self = result;
+    return result;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  public AppleBuilder but() {
+    return (AppleBuilder)clone();
+  }
+
+  /**
+   * Creates a new {@link Apple} based on this builder's settings.
+   *
+   * @return the created Apple
+   */
+  @Override
+  public Apple build() {
+    try {
+      Apple result = new Apple();
+      if (isSet$colour$java$lang$String) {
+        result.colour = value$colour$java$lang$String;
+      }
+      if (isSet$variety$java$lang$String) {
+        result.variety = value$variety$java$lang$String;
+      }
+      return result;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
+    }
+  }
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/Fruit.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/Fruit.java
@@ -1,0 +1,13 @@
+package net.karneim.pojobuilder.processor.with.builderinheritance;
+
+import net.karneim.pojobuilder.GeneratePojoBuilder;
+
+@GeneratePojoBuilder
+public class Fruit {
+  public String colour;
+}
+
+@GeneratePojoBuilder(withBaseclass=FruitBuilder.class)
+class Apple extends Fruit {
+  public String variety;
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/FruitBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/builderinheritance/FruitBuilder.java
@@ -1,0 +1,74 @@
+package net.karneim.pojobuilder.processor.with.builderinheritance;
+
+import javax.annotation.Generated;
+
+@Generated("PojoBuilder")
+public class FruitBuilder
+    implements Cloneable {
+  protected FruitBuilder self;
+  protected String value$colour$java$lang$String;
+  protected boolean isSet$colour$java$lang$String;
+
+  /**
+   * Creates a new {@link FruitBuilder}.
+   */
+  public FruitBuilder() {
+    self = (FruitBuilder)this;
+  }
+
+  /**
+   * Sets the default value for the {@link Fruit#colour} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public FruitBuilder withColour(String value) {
+    this.value$colour$java$lang$String = value;
+    this.isSet$colour$java$lang$String = true;
+    return self;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  @Override
+  public Object clone() {
+    try {
+      FruitBuilder result = (FruitBuilder)super.clone();
+      result.self = result;
+      return result;
+    } catch (CloneNotSupportedException e) {
+      throw new InternalError(e.getMessage());
+    }
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  public FruitBuilder but() {
+    return (FruitBuilder)clone();
+  }
+
+  /**
+   * Creates a new {@link Fruit} based on this builder's settings.
+   *
+   * @return the created Fruit
+   */
+  public Fruit build() {
+    try {
+      Fruit result = new Fruit();
+      if (isSet$colour$java$lang$String) {
+        result.colour = value$colour$java$lang$String;
+      }
+      return result;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new java.lang.reflect.UndeclaredThrowableException(ex);
+    }
+  }
+}


### PR DESCRIPTION
This allows
  `public class AppleBuilder extends FruitBuilder`
to be generated and, provided all withMethods override, used as an abstract `FruitBuilder`.

It's ugly but effective. One day it can be followed up with a change that generates only an interface from an abstract pojo.