### PR TITLE
Add section for gradle 5.0 for annotationProcessor change

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,17 @@ The wiki contains an [extended Gradle script] that distinguishes completely betw
 
 There is [another Gradle script] that enables PojoBuilder for Eclipse IDE.
 
+#### Gradle 5.0
+
+With Gradle 5.0 any annotation processor in the classpath don't get executed anymore.
+To make pojobuilder work again, replace the used dependency scope with `annotationProcessor`
+
+```groovy
+dependencies {
+  annotationProcessor 'net.karneim:pojobuilder:4.2.2'
+}
+```
+
 ### Using Ant
 
 Here is a code snippet of some [sample ANT build script] that runs the PojoBuilder annotation processor within the `javac` task.


### PR DESCRIPTION
Added a section on the readme about the gradle 5.0 annotationProcessor path change.
Simple and advanced configuration was tested (advanced can be seen [here](https://github.com/Poeschl/Pojobuilder-Sourceset-Example/blob/master/build.gradle#L44))

closes #153  