### PR TITLE
Fix #154 - Fields using static inner classes with same name generate overlapping imports

### DIFF
--- a/src/main/java/net/karneim/pojobuilder/model/ImportTypesM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/ImportTypesM.java
@@ -48,7 +48,4 @@ public class ImportTypesM {
       }
     }
   }
-
-
-
 }

--- a/src/main/java/net/karneim/pojobuilder/model/PropertyM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/PropertyM.java
@@ -87,7 +87,7 @@ public class PropertyM {
     } else {
       typeParam = basicType;
     }
-    return new TypeM(interfaceType.getPackageName(), interfaceType.getSimpleName())
+    return new TypeM(interfaceType.getPackageName(), interfaceType.getSimpleNames())
         .withTypeParameter(new TypeWildcardM().whichExtends(typeParam));
   }
 
@@ -111,7 +111,7 @@ public class PropertyM {
       typeParam = propertyType;
     }
     TypeM optionalType = optional.getType();
-    TypeM result = new TypeM(optionalType.getPackageName(), optionalType.getSimpleName())
+    TypeM result = new TypeM(optionalType.getPackageName(), optionalType.getSimpleNames())
         .withTypeParameter(new TypeWildcardM().whichExtends(typeParam));
     return result;
   }

--- a/src/main/java/net/karneim/pojobuilder/model/TypeM.java
+++ b/src/main/java/net/karneim/pojobuilder/model/TypeM.java
@@ -3,6 +3,7 @@ package net.karneim.pojobuilder.model;
 public class TypeM {
   private final String packageName;
   private final String simpleName;
+  private final String simpleNames;
   private final String name;
   private final TypeListM typeParameters = new TypeListM();
 
@@ -10,17 +11,17 @@ public class TypeM {
     this("", name);
   }
 
-  public TypeM(String packageName, String simpleName) {
+  public TypeM(String packageName, String simpleNames) {
     if (packageName == null) {
-      this.packageName = "";
-    } else {
-      this.packageName = packageName;
+      packageName = "";
     }
-    this.simpleName = simpleName;
-    if (this.packageName.isEmpty()) {
-      this.name = simpleName;
+    this.packageName = packageName;
+    this.simpleNames = simpleNames;
+    this.simpleName = simpleNames.substring(simpleNames.lastIndexOf('.') + 1);
+    if (packageName.isEmpty()) {
+      this.name = simpleNames;
     } else {
-      this.name = this.packageName + "." + this.simpleName;
+      this.name = packageName + "." + simpleNames;
     }
   }
 
@@ -41,6 +42,10 @@ public class TypeM {
 
   public String getSimpleName() {
     return simpleName;
+  }
+
+  public String getSimpleNames() {
+    return simpleNames;
   }
 
   public String getName() {
@@ -126,8 +131,6 @@ public class TypeM {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((name == null) ? 0 : name.hashCode());
-    result = prime * result + ((packageName == null) ? 0 : packageName.hashCode());
-    result = prime * result + ((simpleName == null) ? 0 : simpleName.hashCode());
     return result;
   }
 
@@ -144,16 +147,6 @@ public class TypeM {
       if (other.name != null)
         return false;
     } else if (!name.equals(other.name))
-      return false;
-    if (packageName == null) {
-      if (other.packageName != null)
-        return false;
-    } else if (!packageName.equals(other.packageName))
-      return false;
-    if (simpleName == null) {
-      if (other.simpleName != null)
-        return false;
-    } else if (!simpleName.equals(other.simpleName))
       return false;
     if (typeParameters == null) {
       if (other.typeParameters != null)

--- a/src/test/java/net/karneim/pojobuilder/processor/with/ambiguousimports/AnnotationProcessor_Import_Test.java
+++ b/src/test/java/net/karneim/pojobuilder/processor/with/ambiguousimports/AnnotationProcessor_Import_Test.java
@@ -2,6 +2,8 @@ package net.karneim.pojobuilder.processor.with.ambiguousimports;
 
 import net.karneim.pojobuilder.processor.AnnotationProcessor;
 import net.karneim.pojobuilder.processor.with.ProcessorTestSupport;
+import net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.PojoWithAmbiguousInnerClassImports;
+import net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.PojoWithAmbiguousInnerClassImportsBuilder;
 import net.karneim.pojobuilder.testenv.JavaProject.Compilation;
 import org.junit.Test;
 
@@ -17,7 +19,7 @@ public class AnnotationProcessor_Import_Test extends ProcessorTestSupport {
    * @scenario the builder is created with appropriate import statements.
    */
   @Test
-  public void testShouldGenerateBuilderWithAppropriateInportProperties() {
+  public void testShouldGenerateBuilderWithAppropriateImportProperties() {
     // Given:
     sourceFor(Pojo.class);
     // When:
@@ -26,6 +28,24 @@ public class AnnotationProcessor_Import_Test extends ProcessorTestSupport {
     assertThat(prj)
         .generatedSameSourceAs(PojoBuilder.class)
         .compiled(PojoBuilder.class)
+        .reported(Compilation.Success);
+  }
+
+  /**
+   * Test for issue <a href="https://github.com/mkarneim/pojobuilder/issues/154">#154</a>.
+   */
+  @Test
+  public void test_ambiguous_inner_class_imports() {
+    // given:
+    sourceFor(PojoWithAmbiguousInnerClassImports.class);
+
+    // when:
+    prj.compile();
+
+    // then:
+    assertThat(prj)
+        .generatedSameSourceAs(PojoWithAmbiguousInnerClassImportsBuilder.class)
+        .compiled(PojoWithAmbiguousInnerClassImportsBuilder.class)
         .reported(Compilation.Success);
   }
 

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/PojoWithAmbiguousInnerClassImports.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/PojoWithAmbiguousInnerClassImports.java
@@ -1,0 +1,9 @@
+package net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses;
+
+import net.karneim.pojobuilder.GeneratePojoBuilder;
+
+@GeneratePojoBuilder
+public class PojoWithAmbiguousInnerClassImports {
+  public net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack1.Outer1.Inner field1;
+  public net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack2.Outer2.Inner field2;
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/PojoWithAmbiguousInnerClassImportsBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/PojoWithAmbiguousInnerClassImportsBuilder.java
@@ -1,0 +1,95 @@
+package net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses;
+
+import javax.annotation.processing.Generated;
+import net.karneim.pojobuilder.GwtIncompatible;
+import net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack1.Outer1.Inner;
+
+@Generated("PojoBuilder")
+public class PojoWithAmbiguousInnerClassImportsBuilder
+    implements Cloneable {
+  protected PojoWithAmbiguousInnerClassImportsBuilder self;
+  protected Inner value$field1$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack1$Outer1$Inner;
+  protected boolean isSet$field1$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack1$Outer1$Inner;
+  protected net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack2.Outer2.Inner value$field2$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack2$Outer2$Inner;
+  protected boolean isSet$field2$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack2$Outer2$Inner;
+
+  /**
+   * Creates a new {@link PojoWithAmbiguousInnerClassImportsBuilder}.
+   */
+  public PojoWithAmbiguousInnerClassImportsBuilder() {
+    self = (PojoWithAmbiguousInnerClassImportsBuilder)this;
+  }
+
+  /**
+   * Sets the default value for the {@link PojoWithAmbiguousInnerClassImports#field1} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public PojoWithAmbiguousInnerClassImportsBuilder withField1(Inner value) {
+    this.value$field1$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack1$Outer1$Inner = value;
+    this.isSet$field1$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack1$Outer1$Inner = true;
+    return self;
+  }
+
+  /**
+   * Sets the default value for the {@link PojoWithAmbiguousInnerClassImports#field2} property.
+   *
+   * @param value the default value
+   * @return this builder
+   */
+  public PojoWithAmbiguousInnerClassImportsBuilder withField2(net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack2.Outer2.Inner value) {
+    this.value$field2$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack2$Outer2$Inner = value;
+    this.isSet$field2$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack2$Outer2$Inner = true;
+    return self;
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  @Override
+  @GwtIncompatible
+  public Object clone() {
+    try {
+      PojoWithAmbiguousInnerClassImportsBuilder result = (PojoWithAmbiguousInnerClassImportsBuilder)super.clone();
+      result.self = result;
+      return result;
+    } catch (CloneNotSupportedException e) {
+      throw new InternalError(e.getMessage());
+    }
+  }
+
+  /**
+   * Returns a clone of this builder.
+   *
+   * @return the clone
+   */
+  @GwtIncompatible
+  public PojoWithAmbiguousInnerClassImportsBuilder but() {
+    return (PojoWithAmbiguousInnerClassImportsBuilder)clone();
+  }
+
+  /**
+   * Creates a new {@link PojoWithAmbiguousInnerClassImports} based on this builder's settings.
+   *
+   * @return the created PojoWithAmbiguousInnerClassImports
+   */
+  public PojoWithAmbiguousInnerClassImports build() {
+    try {
+      PojoWithAmbiguousInnerClassImports result = new PojoWithAmbiguousInnerClassImports();
+      if (isSet$field1$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack1$Outer1$Inner) {
+        result.field1 = value$field1$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack1$Outer1$Inner;
+      }
+      if (isSet$field2$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack2$Outer2$Inner) {
+        result.field2 = value$field2$net$karneim$pojobuilder$processor$with$ambiguousimports$innerclasses$pack2$Outer2$Inner;
+      }
+      return result;
+    } catch (RuntimeException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/PojoWithAmbiguousInnerClassImportsBuilder.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/PojoWithAmbiguousInnerClassImportsBuilder.java
@@ -1,6 +1,6 @@
 package net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses;
 
-import javax.annotation.processing.Generated;
+import javaxfake.annotation.Generated;
 import net.karneim.pojobuilder.GwtIncompatible;
 import net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack1.Outer1.Inner;
 

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/pack1/Outer1.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/pack1/Outer1.java
@@ -1,0 +1,7 @@
+package net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack1;
+
+public class Outer1 {
+  public static class Inner {
+
+  }
+}

--- a/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/pack2/Outer2.java
+++ b/src/testdata/java/net/karneim/pojobuilder/processor/with/ambiguousimports/innerclasses/pack2/Outer2.java
@@ -1,0 +1,7 @@
+package net.karneim.pojobuilder.processor.with.ambiguousimports.innerclasses.pack2;
+
+public class Outer2 {
+  public static class Inner {
+
+  }
+}


### PR DESCRIPTION
This is a proposed fix for #154. During the fix I noticed that a similar issue exists specifically for optional types. I opened #156 for that.